### PR TITLE
Add `gh_environment` line to workflows

### DIFF
--- a/.github/workflows/deploy-prod&demo.yaml
+++ b/.github/workflows/deploy-prod&demo.yaml
@@ -13,6 +13,7 @@ jobs:
     with:
       app_name: fdk-llm-search-service
       environment: prod
+      gh_environment: prod
       java_version: '21'
       coverage_file_path: ./target/site/jacoco/jacoco.xml
     secrets:
@@ -25,6 +26,7 @@ jobs:
     with:
       app_name: fdk-llm-search-service
       environment: prod
+      gh_environment: prod
       cluster: digdir-fdk-prod
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -38,6 +40,7 @@ jobs:
     with:
       app_name: fdk-llm-search-service
       environment: demo
+      gh_environment: demo
       cluster: digdir-fdk-dev
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -14,6 +14,7 @@ jobs:
     with:
       app_name: fdk-llm-search-service
       environment: staging
+      gh_environment: staging
       java_version: '21'
       coverage_file_path: ./target/site/jacoco/jacoco.xml
     secrets:
@@ -27,6 +28,7 @@ jobs:
     with:
       app_name: fdk-llm-search-service
       environment: staging
+      gh_environment: staging
       cluster: digdir-fdk-dev
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds `gh_environment: <env>` after each `environment: <env>` line in key workflows.