### PR TITLE
refactor: move prompt template to resource file

### DIFF
--- a/src/main/kotlin/no/digdir/fdk/search/llm/configuration/AiProperties.kt
+++ b/src/main/kotlin/no/digdir/fdk/search/llm/configuration/AiProperties.kt
@@ -4,7 +4,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties("ai")
 data class AiProperties(
-    var vertex: VertexProperties? = null
+    var vertex: VertexProperties? = null,
+    var search: SearchProperties? = null,
 )
 
 data class VertexProperties(
@@ -15,4 +16,9 @@ data class VertexProperties(
     var topK: Int? = null,
     var topP: Double? = null,
     var temperature: Float? = null
+)
+
+data class SearchProperties(
+    var numMatches: Int = 10,
+    var simThreshold: Float = 0.3f,
 )

--- a/src/main/kotlin/no/digdir/fdk/search/llm/service/LlmSearchService.kt
+++ b/src/main/kotlin/no/digdir/fdk/search/llm/service/LlmSearchService.kt
@@ -4,10 +4,13 @@ package no.digdir.fdk.search.llm.service
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import dev.langchain4j.model.input.PromptTemplate
+import no.digdir.fdk.search.llm.configuration.AiProperties
+import no.digdir.fdk.search.llm.configuration.SearchProperties
 import no.digdir.fdk.search.llm.model.*
 import no.digdir.fdk.search.llm.repository.SearchQueryRepository
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.springframework.core.io.ClassPathResource
 import org.springframework.stereotype.Component
 
 
@@ -15,10 +18,14 @@ import org.springframework.stereotype.Component
 class LlmSearchService(
     private val vertexService: VertexService,
     private val embeddingService: EmbeddingService,
-    private val searchQueryRepository: SearchQueryRepository
+    private val searchQueryRepository: SearchQueryRepository,
+    private val aiProperties: AiProperties,
 ) {
     private val minQueryLength = 3
     private val maxQueryLength = 255
+
+    internal val promptTemplate: String =
+        ClassPathResource(PROMPT_RESOURCE_PATH).inputStream.bufferedReader().use { it.readText() }
 
     private fun validateQuery(query: String) {
         if (query.length < minQueryLength) {
@@ -42,10 +49,11 @@ class LlmSearchService(
 
         // Perform similarity search, filtered by resource type (defaults to DATASET, use ALL for all types)
         val searchType = if (searchOperation.type == SearchType.ALL) null else searchOperation.type
+        val search = aiProperties.search ?: SearchProperties()
         val embeddings = embeddingService.similaritySearch(
-            query, searchType, SIM_THRESHOLD, NUM_MATCHES)
+            query, searchType, search.simThreshold, search.numMatches)
 
-        val message = PromptTemplate.from(PROMPT_TEMPLATE).apply(
+        val message = PromptTemplate.from(promptTemplate).apply(
             mapOf(
                 "summaries" to objectMapper.writeValueAsString(embeddings),
                 "user_query" to query
@@ -99,31 +107,6 @@ class LlmSearchService(
 
         private val objectMapper: ObjectMapper = jacksonObjectMapper()
 
-        private const val NUM_MATCHES = 10
-        private const val SIM_THRESHOLD = 0.3f
-
-        private val PROMPT_TEMPLATE = """
-            You will be given a detailed summaries of different resources (datasets, concepts, data services, information models, services, and events) in norwegian as a JSON array.
-            The question is enclosed in double backticks(``).
-            Select all resources that are relevant to answer the question.
-            Prioritize resources with newer data when applicable.
-            Using those resource summaries, answer the question in as much detail as possible. 
-            Give your answer in Norwegian.
-            You should only use the information in the summaries.
-            Your answer should start with explaining if the question contains possible personal sensitive data 
-            (sensitive) and why each resource matches the question posed by the user (reason).
-            Format the result as JSON only using the following structure format the description in Markdown: 
-            ```json
-            { "sensitive": true/false, "hits": [ { "id": "", "name": "", "reason": "" } ] }
-            ```
-                                            
-            Summaries:
-            ```json
-            {{summaries}}
-            ```        
-                    
-            Question:
-            ``{{user_query}}``            
-            """.trimIndent()
+        private const val PROMPT_RESOURCE_PATH = "prompts/search-prompt.md"
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -61,6 +61,9 @@ ai:
     topK: ${AI_VERTEX_TOP_K:1}
     topP: ${AI_VERTEX_TOP_P:0.8}
     temperature: ${AI_VERTEX_TEMPERATURE:0.0}
+  search:
+    numMatches: ${AI_SEARCH_NUM_MATCHES:10}
+    simThreshold: ${AI_SEARCH_SIM_THRESHOLD:0.3}
 application:
   prop: 1
   cors:

--- a/src/main/resources/prompts/search-prompt.md
+++ b/src/main/resources/prompts/search-prompt.md
@@ -1,0 +1,21 @@
+You will be given a detailed summaries of different resources (datasets, concepts, data services, information models, services, and events) in norwegian as a JSON array.
+The question is enclosed in double backticks(``).
+Select all resources that are relevant to answer the question.
+Prioritize resources with newer data when applicable.
+Using those resource summaries, answer the question in as much detail as possible. 
+Give your answer in Norwegian.
+You should only use the information in the summaries.
+Your answer should start with explaining if the question contains possible personal sensitive data 
+(sensitive) and why each resource matches the question posed by the user (reason).
+Format the result as JSON only using the following structure format the description in Markdown: 
+```json
+{ "sensitive": true/false, "hits": [ { "id": "", "name": "", "reason": "" } ] }
+```
+                                
+Summaries:
+```json
+{{summaries}}
+```        
+        
+Question:
+``{{user_query}}``            

--- a/src/test/kotlin/no/digdir/fdk/search/llm/service/LlmSearchServiceTest.kt
+++ b/src/test/kotlin/no/digdir/fdk/search/llm/service/LlmSearchServiceTest.kt
@@ -3,6 +3,8 @@ package no.digdir.fdk.search.llm.service
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import no.digdir.fdk.search.llm.configuration.AiProperties
+import no.digdir.fdk.search.llm.configuration.SearchProperties
 import no.digdir.fdk.search.llm.model.LlmSearchOperation
 import no.digdir.fdk.search.llm.model.SearchType
 import no.digdir.fdk.search.llm.model.TextEmbedding
@@ -11,14 +13,22 @@ import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.springframework.test.context.ActiveProfiles
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 @ActiveProfiles("test")
 class LlmSearchServiceTest {
     private val vertexService = mockk<VertexService>()
     private val embeddingService = mockk<EmbeddingService>()
     private val searchQueryRepository = mockk<SearchQueryRepository>()
+    private val aiProperties = AiProperties(search = SearchProperties(numMatches = 10, simThreshold = 0.3f))
 
-    private val llmSearchService = LlmSearchService(vertexService, embeddingService, searchQueryRepository)
+    private val llmSearchService = LlmSearchService(vertexService, embeddingService, searchQueryRepository, aiProperties)
+
+    @Test
+    fun `prompt template is loaded from classpath resource`() {
+        assertTrue(llmSearchService.promptTemplate.contains("{{summaries}}"))
+        assertTrue(llmSearchService.promptTemplate.contains("{{user_query}}"))
+    }
 
     @Test
     fun `llm search should return three hits`() {


### PR DESCRIPTION
# Summary fixes #120

- Move PROMPT_TEMPLATE to `src/main/resources/prompts/search-prompt.md`
- Load prompt via ClassPathResource on startup
- Add SearchProperties (numMatches, simThreshold) to AiProperties
- Bind search config to application.yaml under `ai.search` with env var overrides
- Update LlmSearchServiceTest with new constructor and prompt-load assertion