### PR TITLE
feat: bump LLM model to gemini-2.5-flash-lite

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -55,7 +55,7 @@ ai:
     endpoint: ${AI_VERTEX_ENDPOINT}
     project: ${AI_VERTEX_PROJECT}
     location: ${AI_VERTEX_LOCATION}
-    llmModelName: ${AI_VERTEX_LLM_MODEL_NAME:gemini-2.0-flash}
+    llmModelName: ${AI_VERTEX_LLM_MODEL_NAME:gemini-2.5-flash-lite}
     embeddingModelName: ${AI_VERTEX_EMBEDDING_MODEL_NAME:text-multilingual-embedding-002}
     maxOutputTokens: ${AI_VERTEX_MAX_OUTPUT_TOKENS:2048}
     topK: ${AI_VERTEX_TOP_K:1}


### PR DESCRIPTION
# Summary fixes #124

- Bump default LLM model from `gemini-2.0-flash` to `gemini-2.5-flash-lite`