### PR TITLE
fix: pass maxOutputTokens and topP to LLM builder

### DIFF
--- a/src/main/kotlin/no/digdir/fdk/search/llm/configuration/AiProperties.kt
+++ b/src/main/kotlin/no/digdir/fdk/search/llm/configuration/AiProperties.kt
@@ -15,7 +15,7 @@ data class VertexProperties(
     var llmModelName: String? = null,
     var embeddingModelName: String? = null,
     var maxOutputTokens: Int? = null,
-    var topP: Double? = null,
+    var topP: Float? = null,
     var temperature: Float? = null
 )
 

--- a/src/main/kotlin/no/digdir/fdk/search/llm/configuration/AiProperties.kt
+++ b/src/main/kotlin/no/digdir/fdk/search/llm/configuration/AiProperties.kt
@@ -15,7 +15,6 @@ data class VertexProperties(
     var llmModelName: String? = null,
     var embeddingModelName: String? = null,
     var maxOutputTokens: Int? = null,
-    var topK: Int? = null,
     var topP: Double? = null,
     var temperature: Float? = null
 )

--- a/src/main/kotlin/no/digdir/fdk/search/llm/configuration/LlmConfig.kt
+++ b/src/main/kotlin/no/digdir/fdk/search/llm/configuration/LlmConfig.kt
@@ -17,6 +17,8 @@ class LlmConfig {
             .project(aiProperties.vertex?.project)
             .location(aiProperties.vertex?.location)
             .temperature(aiProperties.vertex?.temperature)
+            .maxOutputTokens(aiProperties.vertex?.maxOutputTokens)
+            .topP(aiProperties.vertex?.topP)
             .modelName(aiProperties.vertex?.llmModelName)
             .responseMimeType("application/json")
             .supportedCapabilities(Capability.RESPONSE_FORMAT_JSON_SCHEMA)

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -58,7 +58,6 @@ ai:
     llmModelName: ${AI_VERTEX_LLM_MODEL_NAME:gemini-2.5-flash-lite}
     embeddingModelName: ${AI_VERTEX_EMBEDDING_MODEL_NAME:text-multilingual-embedding-002}
     maxOutputTokens: ${AI_VERTEX_MAX_OUTPUT_TOKENS:2048}
-    topK: ${AI_VERTEX_TOP_K:1}
     topP: ${AI_VERTEX_TOP_P:0.8}
     temperature: ${AI_VERTEX_TEMPERATURE:0.0}
   search:


### PR DESCRIPTION
# Summary fixes #126

- Pass `maxOutputTokens` and `topP` from config to `VertexAiGeminiChatModel.builder()`
- Remove unused `topK` from `application.yaml` and `AiProperties`